### PR TITLE
Fix WebGL context creation

### DIFF
--- a/src/components/Carousel/Carousel.js
+++ b/src/components/Carousel/Carousel.js
@@ -74,7 +74,6 @@ export const Carousel = ({ width, height, images, placeholder, ...rest }) => {
       antialias: false,
       alpha: true,
       powerPreference: 'high-performance',
-      failIfMajorPerformanceCaveat: true,
     });
     camera.current = new OrthographicCamera(...cameraOptions);
     scene.current = new Scene();

--- a/src/components/Model/Model.js
+++ b/src/components/Model/Model.js
@@ -94,7 +94,6 @@ export const Model = ({
       alpha: true,
       antialias: false,
       powerPreference: 'high-performance',
-      failIfMajorPerformanceCaveat: true,
     });
 
     renderer.current.setPixelRatio(2);

--- a/src/layouts/Home/DisplacementSphere.js
+++ b/src/layouts/Home/DisplacementSphere.js
@@ -57,7 +57,6 @@ export const DisplacementSphere = props => {
       antialias: false,
       alpha: true,
       powerPreference: 'high-performance',
-      failIfMajorPerformanceCaveat: true,
     });
     renderer.current.setSize(innerWidth, innerHeight);
     renderer.current.setPixelRatio(1);

--- a/src/pages/projects/smart-sparrow/Earth.js
+++ b/src/pages/projects/smart-sparrow/Earth.js
@@ -196,7 +196,6 @@ export const Earth = ({
       antialias: false,
       alpha: true,
       powerPreference: 'high-performance',
-      failIfMajorPerformanceCaveat: true,
     });
     renderer.current.setPixelRatio(1);
     renderer.current.outputEncoding = sRGBEncoding;

--- a/src/pages/projects/volkihar-knight/Armor.js
+++ b/src/pages/projects/volkihar-knight/Armor.js
@@ -63,7 +63,6 @@ export const Armor = ({
       alpha: true,
       antialias: false,
       powerPreference: 'high-performance',
-      failIfMajorPerformanceCaveat: true,
     });
 
     renderer.current.setPixelRatio(2);


### PR DESCRIPTION
## Summary
- remove `failIfMajorPerformanceCaveat` to allow fallback WebGL contexts

## Testing
- `npm test`
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68767b392650832f99d435b10dd6ced0