### PR TITLE
Fix draco path

### DIFF
--- a/scripts/draco-storybook.js
+++ b/scripts/draco-storybook.js
@@ -2,7 +2,7 @@ const fs = require('fs-extra');
 
 // Copy draco decoder from three.js into the storybook build directory
 fs.copy(
-  'node_modules/three/examples/js/libs/draco/gltf/',
+  'node_modules/three/examples/jsm/libs/draco/gltf/',
   'build-storybook/draco',
   err => {
     if (err) return console.error(err);

--- a/scripts/draco.js
+++ b/scripts/draco.js
@@ -1,6 +1,6 @@
 const fs = require('fs-extra');
 
 // Copy draco decoder from three.js into the public directory
-fs.copy('node_modules/three/examples/js/libs/draco/gltf/', 'public/draco', err => {
+fs.copy('node_modules/three/examples/jsm/libs/draco/gltf/', 'public/draco', err => {
   if (err) return console.error(err);
 });


### PR DESCRIPTION
## Summary
- update draco decoder path in build scripts

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876f9c5d258832fbe8d89f55839dbb7