### PR TITLE
Handle WebGL availability check without creating renderer

### DIFF
--- a/src/utils/three.js
+++ b/src/utils/three.js
@@ -1,4 +1,4 @@
-import { Cache, TextureLoader, WebGLRenderer } from 'three';
+import { Cache, TextureLoader } from 'three';
 import { DRACOLoader, GLTFLoader } from 'three-stdlib';
 
 // Enable caching for all loaders
@@ -32,9 +32,7 @@ export const isWebGLAvailable = () => {
     const loseContext = gl.getExtension('WEBGL_lose_context');
     loseContext?.loseContext();
 
-    // Attempt to create a renderer to ensure context creation doesn't fail
-    const renderer = new WebGLRenderer({ canvas });
-    renderer.dispose();
+    // If we could create a WebGL context the environment supports WebGL
 
     return true;
   } catch {


### PR DESCRIPTION
## Summary
- simplify WebGL support check to avoid errors when a renderer cannot be created

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687701cdda74832f8cb7604edb630bc0